### PR TITLE
Small sentence improvement

### DIFF
--- a/book-content/chapters/04-essential-types-and-annotations.md
+++ b/book-content/chapters/04-essential-types-and-annotations.md
@@ -1198,7 +1198,7 @@ One way to fix this would be to pass some values to `Set` so it understands what
 const formats = new Set(["CD", "DVD"]);
 ```
 
-But, we don't _want_ to pass any values to it initially.
+But, we might not _want_ to pass any values to it initially.
 
 We can get around this by passing a _type_ to `Set` when we call it, using the angle brackets syntax:
 


### PR DESCRIPTION
When I first read "But, we don't _want_ to pass any values to it initially.", I thought "But it might be ok to pass values initially, why would I never want to pass any value"
With my version proposition, I think it removed this question and keeps the original intention.