### PR TITLE
Update 04 (Rest Parameters) - Add "rest" operator for "formats" parameter

### DIFF
--- a/book-content/chapters/04-essential-types-and-annotations.md
+++ b/book-content/chapters/04-essential-types-and-annotations.md
@@ -1550,7 +1550,7 @@ getAlbumFormats(
 As an alternative, we can use the `Array<>` syntax instead.
 
 ```typescript
-function getAlbumFormats(album: Album, formats: Array<string>) {
+function getAlbumFormats(album: Album, ...formats: Array<string>) {
   // function body
 }
 ```


### PR DESCRIPTION
Rest Parameters section. It seems to me that in the second example (for Array<> syntax) there should also be a "rest" operator before the "formats" parameter.