### PR TITLE
Fix union types example

### DIFF
--- a/book-content/chapters/05-unions-literals-and-narrowing.md
+++ b/book-content/chapters/05-unions-literals-and-narrowing.md
@@ -9,7 +9,6 @@ A union type is TypeScript's way of saying that a value can be "either this type
 This situation comes up in JavaScript all the time. Imagine you have a value that is a `string` on Tuesdays, but `null` the rest of the time:
 
 ```ts twoslash
-const message = Date.now() % 2 === 0 ? "Hello Tuesdays!" : null;
 const message = (new Date()).getDay() === 2 ? 'Hello Tuesdays!' : null;
 //    ^?
 ```

--- a/book-content/chapters/05-unions-literals-and-narrowing.md
+++ b/book-content/chapters/05-unions-literals-and-narrowing.md
@@ -10,6 +10,7 @@ This situation comes up in JavaScript all the time. Imagine you have a value tha
 
 ```ts twoslash
 const message = Date.now() % 2 === 0 ? "Hello Tuesdays!" : null;
+const message = (new Date()).getDay() === 2 ? 'Hello Tuesdays!' : null;
 //    ^?
 ```
 


### PR DESCRIPTION
**What**

Fixes the logic in the following example code used in Chapter 5: Unions, Literals and Narrowing

Imagine you have a value that is a string on Tuesdays, but null the rest of the time:

```ts
const message = Date.now() % 2 === 0 ? 'Hello Tuesdays!' : null
```

`Date.now()` returns the number of milliseconds elapsed since the epoch.

[See in MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now)

Applying the modulo operator to a number results in message being either a string literal ('Hello Tuesdays!') or null, irrespective of whether it's Tuesday or not.

**How**

We can use `new Date()` and the `.getDay()` method to get the current day as an index and check if it's Tuesday (index number 2).

```ts
const message = (new Date()).getDay() === 2 ? 'Hello Tuesdays!' : null
```

[See in MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay)

[View in the TypeScript Playground](https://tsplay.dev/WY7rdN)