### PR TITLE
Fix typo for visual represent.

### DIFF
--- a/book-content/chapters/05-unions-literals-and-narrowing.md
+++ b/book-content/chapters/05-unions-literals-and-narrowing.md
@@ -111,7 +111,7 @@ type DigitalFormat = "MP3" | "FLAC";
 type PhysicalFormat = "LP" | "CD" | "Cassette";
 ```
 
-We could then specify `AlbumFormat` as a union of `DigitalFormat` and `PhysicalFormat:
+We could then specify `AlbumFormat` as a union of `DigitalFormat` and `PhysicalFormat`:
 
 ```tsx
 type AlbumFormat = DigitalFormat | PhysicalFormat;


### PR DESCRIPTION
Fix small typo for fixing the visual represent for  `PhysicalFormat`